### PR TITLE
feat: set default subnet delegation naming

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -95,7 +95,6 @@ module "network" {
 
       delegation = [
         {
-          name                       = "delegation"
           service_delegation_name    = "Microsoft.ContainerInstance/containerGroups"
           service_delegation_actions = ["Microsoft.Network/virtualNetworks/subnets/join/action", "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action"]
         }

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,10 @@ resource "azurerm_subnet" "this" {
     for_each = each.value["delegation"]
 
     content {
-      name = delegation.value["name"]
+      # If a name is not explicitly set, set it to the index of the current object.
+      # E.g., if two subnet delegations are to be configured, the first delegation will be named "0" and the second will be named "1".
+      # This is the default naming convention when creating a subnet delegation in the Azure Portal.
+      name = coalesce(delegation.value["name"], index(each.value["delegation"], delegation.value))
 
       service_delegation {
         name    = delegation.value["service_delegation_name"]

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ variable "subnets" {
     service_endpoints = optional(list(string), [])
 
     delegation = optional(list(object({
-      name                       = string
+      name                       = optional(string)
       service_delegation_name    = string
       service_delegation_actions = optional(list(string), [])
     })), [])


### PR DESCRIPTION
Simplify creation of subnet delegations by setting a default name that follows the same naming convention as when creating delegations using the Azure Portal.