### PR TITLE
feat(nsg)!: send logs to Log Analytics

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -58,9 +58,11 @@ module "nsg" {
   # source = "github.com/equinor/terraform-azurerm-network//modules/nsg?ref=v0.0.0"
   source = "../../modules/nsg"
 
-  nsg_name            = "nsg-${random_id.this.hex}"
-  resource_group_name = azurerm_resource_group.this.name
-  location            = azurerm_resource_group.this.location
+  nsg_name                   = "nsg-${random_id.this.hex}"
+  resource_group_name        = azurerm_resource_group.this.name
+  location                   = azurerm_resource_group.this.location
+  log_analytics_workspace_id = module.log_analytics.workspace_id
+
 
   security_rules = [
     {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -58,9 +58,11 @@ module "nsg" {
   # source = "github.com/equinor/terraform-azurerm-network//modules/nsg?ref=v0.0.0"
   source = "../../modules/nsg"
 
-  nsg_name            = "nsg-${random_id.this.hex}"
-  resource_group_name = azurerm_resource_group.this.name
-  location            = azurerm_resource_group.this.location
+  nsg_name                   = "nsg-${random_id.this.hex}"
+  resource_group_name        = azurerm_resource_group.this.name
+  location                   = azurerm_resource_group.this.location
+  log_analytics_workspace_id = module.log_analytics.workspace_id
+
 
   security_rules = [
     {
@@ -158,14 +160,6 @@ module "nic" {
   }
 
   tags = local.tags
-}
-
-resource "azurerm_public_ip" "example" {
-  name                = "pip-${random_id.this.hex}"
-  resource_group_name = azurerm_resource_group.this.name
-  location            = azurerm_resource_group.this.location
-  sku                 = "Standard"
-  allocation_method   = "Static"
 }
 
 module "public_ip" {

--- a/modules/nsg/main.tf
+++ b/modules/nsg/main.tf
@@ -35,3 +35,18 @@ resource "azurerm_network_security_group" "this" {
 
   tags = var.tags
 }
+
+resource "azurerm_monitor_diagnostic_setting" "this" {
+  name                           = var.diagnostic_setting_name
+  target_resource_id             = azurerm_network_security_group.this.id
+  log_analytics_workspace_id     = var.log_analytics_workspace_id
+  log_analytics_destination_type = var.log_analytics_destination_type
+
+  dynamic "enabled_log" {
+    for_each = toset(var.diagnostic_setting_enabled_log_categories)
+
+    content {
+      category = enabled_log.value
+    }
+  }
+}

--- a/modules/nsg/variables.tf
+++ b/modules/nsg/variables.tf
@@ -36,6 +36,33 @@ variable "security_rules" {
   default = []
 }
 
+variable "diagnostic_setting_name" {
+  description = "The name of this diagnostic setting."
+  type        = string
+  default     = "audit-logs"
+}
+
+variable "diagnostic_setting_enabled_log_categories" {
+  description = "A list of log categories to be enabled for this diagnostic setting."
+  type        = list(string)
+  default = [
+    "NetworkSecurityGroupEvent",
+    "NetworkSecurityGroupRuleCounter"
+  ]
+}
+
+variable "log_analytics_workspace_id" {
+  description = "The ID of the Log Analytics workspace to send diagnostics to."
+  type        = string
+}
+
+variable "log_analytics_destination_type" {
+  description = "The type of log analytics destination to use for this Log Analytics Workspace."
+  type        = string
+  default     = null
+}
+
+
 variable "tags" {
   description = "A map of tags to assign to the resources."
   type        = map(string)


### PR DESCRIPTION
created a diagnostic setting to the sub-module `nsg`, and the reason for this being marked as a breaking change, is because this required a new variable log_analytics_workspace_id. this fixes #33. And because there was a prior error involving the merging of a public ip, this will also fix #37 