### PR TITLE
chore: add separate vNet peering example

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -19,33 +19,6 @@ resource "azurerm_resource_group" "example" {
   tags = local.tags
 }
 
-module "network_hub" {
-  # source = "github.com/equinor/terraform-azurerm-network?ref=v0.0.0"
-  source = "../.."
-
-  vnet_name           = "vnet-hub-${random_id.suffix.hex}"
-  resource_group_name = azurerm_resource_group.example.name
-  location            = azurerm_resource_group.example.location
-  address_spaces      = ["10.0.0.0/16"]
-  dns_servers         = ["10.0.0.4", "10.0.0.5"]
-
-  subnets = {
-    "default" = {
-      name             = "snet-default-${random_id.suffix.hex}"
-      address_prefixes = ["10.0.1.0/24"]
-    }
-  }
-
-  virtual_network_peerings = {
-    "example" = {
-      name                      = "example-peering"
-      remote_virtual_network_id = module.network.vnet_id
-    }
-  }
-
-  tags = local.tags
-}
-
 resource "azurerm_network_security_group" "example" {
   name                = "nsg-${random_id.suffix.hex}"
   resource_group_name = azurerm_resource_group.example.name
@@ -105,13 +78,6 @@ module "network" {
       nat_gateway_association = {
         nat_gateway_id = azurerm_nat_gateway.example.id
       }
-    }
-  }
-
-  virtual_network_peerings = {
-    "hub" = {
-      name                      = "hub-peering"
-      remote_virtual_network_id = module.network_hub.vnet_id
     }
   }
 

--- a/examples/vnet-peering/README.md
+++ b/examples/vnet-peering/README.md
@@ -1,0 +1,5 @@
+# vNet peering example
+
+Example Terraform configuration which shows how to use this module to configure virtual network peerings.
+
+It sets up a two vNets, one hub and one spoke, then configures the peering between them.

--- a/examples/vnet-peering/main.tf
+++ b/examples/vnet-peering/main.tf
@@ -32,7 +32,7 @@ module "network_hub" {
   virtual_network_peerings = {
     "spoke" = {
       name                      = "spoke-01-peering"
-      remote_virtual_network_id = module.network_spoke.vnet_id
+      remote_virtual_network_id = module.network_spoke_01.vnet_id
     }
   }
 }

--- a/examples/vnet-peering/main.tf
+++ b/examples/vnet-peering/main.tf
@@ -9,8 +9,6 @@ resource "random_id" "suffix" {
 resource "azurerm_resource_group" "example" {
   name     = "rg-${random_id.suffix.hex}"
   location = var.location
-
-  tags = local.tags
 }
 
 module "network_hub" {

--- a/examples/vnet-peering/main.tf
+++ b/examples/vnet-peering/main.tf
@@ -1,0 +1,62 @@
+provider "azurerm" {
+  features {}
+}
+
+resource "random_id" "suffix" {
+  byte_length = 8
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "rg-${random_id.suffix.hex}"
+  location = var.location
+
+  tags = local.tags
+}
+
+module "network_hub" {
+  # source = "github.com/equinor/terraform-azurerm-network?ref=v0.0.0"
+  source = "../.."
+
+  vnet_name           = "vnet-hub-${random_id.suffix.hex}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  address_spaces      = ["10.0.0.0/16"]
+
+  subnets = {
+    "default" = {
+      name             = "default"
+      address_prefixes = ["10.0.1.0/24"]
+    }
+  }
+
+  virtual_network_peerings = {
+    "spoke" = {
+      name                      = "spoke-01-peering"
+      remote_virtual_network_id = module.network_spoke.vnet_id
+    }
+  }
+}
+
+module "network_spoke_01" {
+  # source = "github.com/equinor/terraform-azurerm-network?ref=v0.0.0"
+  source = "../.."
+
+  vnet_name           = "vnet-spoke-01-${random_id.suffix.hex}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  address_spaces      = ["10.1.0.0/16"]
+
+  subnets = {
+    "default" = {
+      name             = "default"
+      address_prefixes = ["10.1.1.0/24"]
+    }
+  }
+
+  virtual_network_peerings = {
+    "hub" = {
+      name                      = "hub-peering"
+      remote_virtual_network_id = module.network_hub.vnet_id
+    }
+  }
+}

--- a/examples/vnet-peering/variables.tf
+++ b/examples/vnet-peering/variables.tf
@@ -1,0 +1,5 @@
+variable "location" {
+  description = "The location to create the resources in."
+  type        = string
+  default     = "northeurope"
+}

--- a/test/vnet_peering_example_test.go
+++ b/test/vnet_peering_example_test.go
@@ -1,0 +1,17 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+func TestVnetPeeringExample(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/vnet-peering",
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraform.InitAndApply(t, terraformOptions)
+}


### PR DESCRIPTION
Add separate example (and corresponding test) for vNet peering.

This reduces the size and complexity of the complete example.
