### PR TITLE
refactor!: simplify subnet configuration

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -28,12 +28,9 @@ module "network" {
 
   subnets = {
     "vm" = {
-      name             = "snet-vm-${random_id.suffix.hex}"
-      address_prefixes = ["10.0.1.0/24"]
-
-      network_security_group = {
-        id = azurerm_network_security_group.example.id
-      }
+      name                      = "snet-vm-${random_id.suffix.hex}"
+      address_prefixes          = ["10.0.1.0/24"]
+      network_security_group_id = azurerm_network_security_group.example.id
     }
   }
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -54,30 +54,11 @@ module "network" {
 
   subnets = {
     "ci" = {
-      name             = "snet-ci-${random_id.suffix.hex}"
-      address_prefixes = ["10.1.1.0/24"]
-
-      service_endpoints = [
-        "Microsoft.Sql",
-        "Microsoft.KeyVault",
-        "Microsoft.Storage"
-      ]
-
-      delegations = [{
-        service_name = "Microsoft.ContainerInstance/containerGroups"
-      }]
-
-      network_security_group = {
-        id = azurerm_network_security_group.example.id
-      }
-
-      route_table = {
-        id = azurerm_route_table.example.id
-      }
-
-      nat_gateway = {
-        id = azurerm_nat_gateway.example.id
-      }
+      name                      = "snet-ci-${random_id.suffix.hex}"
+      address_prefixes          = ["10.1.1.0/24"]
+      network_security_group_id = azurerm_network_security_group.example.id
+      service_endpoints         = ["Microsoft.Sql", "Microsoft.KeyVault", "Microsoft.Storage"]
+      service_delegation_name   = "Microsoft.ContainerInstance/containerGroups"
     }
   }
 

--- a/examples/vnet-peering/main.tf
+++ b/examples/vnet-peering/main.tf
@@ -28,12 +28,9 @@ module "network_hub" {
 
   subnets = {
     "default" = {
-      name             = "default"
-      address_prefixes = ["10.0.1.0/24"]
-
-      network_security_group = {
-        id = azurerm_network_security_group.example.id
-      }
+      name                      = "default"
+      address_prefixes          = ["10.0.1.0/24"]
+      network_security_group_id = azurerm_network_security_group.example.id
     }
   }
 
@@ -56,12 +53,9 @@ module "network_spoke_01" {
 
   subnets = {
     "default" = {
-      name             = "default"
-      address_prefixes = ["10.1.1.0/24"]
-
-      network_security_group = {
-        id = azurerm_network_security_group.example.id
-      }
+      name                      = "default"
+      address_prefixes          = ["10.1.1.0/24"]
+      network_security_group_id = azurerm_network_security_group.example.id
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "azurerm_subnet" "this" {
   service_endpoints    = each.value["service_endpoints"]
 
   dynamic "delegation" {
-    for_each = each.value["delegation_service_name"] != null ? [0] : []
+    for_each = each.value["service_delegation_name"] != null ? [0] : []
 
     content {
       name = "0"

--- a/variables.tf
+++ b/variables.tf
@@ -32,10 +32,8 @@ variable "subnets" {
     address_prefixes          = list(string)
     network_security_group_id = string
 
-    delegation_service_name    = optional(string)
-    delegation_service_actions = optional(list(string), ["Microsoft.Network/virtualNetworks/subnets/action"])
-
-    service_endpoints = optional(list(string), [])
+    service_delegation_name = optional(string)
+    service_endpoints       = optional(list(string), [])
   }))
 
   default = {}

--- a/variables.tf
+++ b/variables.tf
@@ -28,29 +28,14 @@ variable "subnets" {
   description = "A map of subnets to create for this virtual network."
 
   type = map(object({
-    name              = string
-    address_prefixes  = list(string)
+    name                      = string
+    address_prefixes          = list(string)
+    network_security_group_id = string
+
+    delegation_service_name    = optional(string)
+    delegation_service_actions = optional(list(string), ["Microsoft.Network/virtualNetworks/subnets/action"])
+
     service_endpoints = optional(list(string), [])
-
-    delegations = optional(list(object({
-      service_name    = string
-      service_actions = optional(list(string), ["Microsoft.Network/virtualNetworks/subnets/action"])
-      name            = optional(string)
-    })), [])
-
-    network_security_group = object({
-      # Wrap an object around the NSG ID.
-      # If the subnet shouldn't be associated with an NSG, set the value of the object to null.
-      id = string
-    })
-
-    route_table = optional(object({
-      id = string
-    }))
-
-    nat_gateway = optional(object({
-      id = string
-    }))
   }))
 
   default = {}

--- a/variables.tf
+++ b/variables.tf
@@ -31,9 +31,8 @@ variable "subnets" {
     name                      = string
     address_prefixes          = list(string)
     network_security_group_id = string
-
-    service_delegation_name = optional(string)
-    service_endpoints       = optional(list(string), [])
+    service_endpoints         = optional(list(string), [])
+    service_delegation_name   = optional(string)
   }))
 
   default = {}


### PR DESCRIPTION
WIP

Current implementation requires associating all subnets to an NSG.

Current implementation removes ability to associate subnets to a route table or NAT gateway.

Should `service_delegation_name` be renamed to `delegation_service_name`? Might make more sense.