### PR TITLE
refactor!: rename subnet association properties

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -56,16 +56,16 @@ module "network" {
       name             = "snet-ci-${random_id.suffix.hex}"
       address_prefixes = ["10.1.1.0/24"]
 
-      network_security_group = {
-        id = azurerm_network_security_group.example.id
+      network_security_group_association = {
+        network_security_group_id = azurerm_network_security_group.example.id
       }
 
-      nat_gateway = {
-        id = azurerm_nat_gateway.example.id
+      nat_gateway_association = {
+        nat_gateway_id = azurerm_nat_gateway.example.id
       }
 
-      route_table = {
-        id = azurerm_route_table.example.id
+      route_table_association = {
+        route_table_id = azurerm_route_table.example.id
       }
 
       service_endpoints = [

--- a/main.tf
+++ b/main.tf
@@ -1,14 +1,14 @@
 locals {
   subnet_route_table_associations = {
-    for k, v in var.subnets : k => v["route_table"].id if v["route_table"] != null
+    for k, v in var.subnets : k => v["route_table_association"] if v["route_table_association"] != null
   }
 
   subnet_network_security_group_associations = {
-    for k, v in var.subnets : k => v["network_security_group"].id if v["network_security_group"] != null
+    for k, v in var.subnets : k => v["network_security_group_association"] if v["network_security_group_association"] != null
   }
 
   subnet_nat_gateway_associations = {
-    for k, v in var.subnets : k => v["nat_gateway"].id if v["nat_gateway"] != null
+    for k, v in var.subnets : k => v["nat_gateway_association"] if v["nat_gateway_association"] != null
   }
 }
 
@@ -62,21 +62,21 @@ resource "azurerm_subnet_network_security_group_association" "this" {
   for_each = local.subnet_network_security_group_associations
 
   subnet_id                 = azurerm_subnet.this[each.key].id
-  network_security_group_id = each.value
+  network_security_group_id = each.value.network_security_group_id
 }
 
 resource "azurerm_subnet_route_table_association" "this" {
   for_each = local.subnet_route_table_associations
 
   subnet_id      = azurerm_subnet.this[each.key].id
-  route_table_id = each.value
+  route_table_id = each.value.route_table_id
 }
 
 resource "azurerm_subnet_nat_gateway_association" "this" {
   for_each = local.subnet_nat_gateway_associations
 
   subnet_id      = azurerm_subnet.this[each.key].id
-  nat_gateway_id = each.value
+  nat_gateway_id = each.value.nat_gateway_id
 }
 
 resource "azurerm_virtual_network_peering" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -31,16 +31,16 @@ variable "subnets" {
     name             = string
     address_prefixes = list(string)
 
-    network_security_group = optional(object({
-      id = string
+    network_security_group_association = optional(object({
+      network_security_group_id = string
     }))
 
-    nat_gateway = optional(object({
-      id = string
+    nat_gateway_association = optional(object({
+      nat_gateway_id = string
     }))
 
-    route_table = optional(object({
-      id = string
+    route_table_association = optional(object({
+      route_table_id = string
     }))
 
     service_endpoints           = optional(list(string), [])


### PR DESCRIPTION
Lesson learned: don't think you're smarter than HashiCorp at naming things unless you have very strong arguments 🙂 

Could be released together with #71, as the outputs added in that PR have been named similarly to the changes in this PR.