### PR TITLE
refactor!: simplify subnet configuration

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -56,24 +56,11 @@ module "network" {
       name             = "snet-ci-${random_id.suffix.hex}"
       address_prefixes = ["10.1.1.0/24"]
 
-      network_security_group = {
-        id = azurerm_network_security_group.example.id
-      }
+      security_group_id = azurerm_network_security_group.example.id
+      route_table_id    = azurerm_route_table.example.id
+      nat_gateway_id    = azurerm_nat_gateway.example.id
 
-      nat_gateway = {
-        id = azurerm_nat_gateway.example.id
-      }
-
-      route_table = {
-        id = azurerm_route_table.example.id
-      }
-
-      service_endpoints = [
-        "Microsoft.Sql",
-        "Microsoft.KeyVault",
-        "Microsoft.Storage"
-      ]
-
+      service_endpoints           = ["Microsoft.Sql", "Microsoft.KeyVault", "Microsoft.Storage"]
       service_endpoint_policy_ids = [azurerm_subnet_service_endpoint_storage_policy.this.id]
 
       delegations = [

--- a/main.tf
+++ b/main.tf
@@ -1,23 +1,41 @@
-locals {
-  subnet_route_table_associations = {
-    for k, v in var.subnets : k => v["route_table"].id if v["route_table"] != null
-  }
-
-  subnet_network_security_group_associations = {
-    for k, v in var.subnets : k => v["network_security_group"].id if v["network_security_group"] != null
-  }
-
-  subnet_nat_gateway_associations = {
-    for k, v in var.subnets : k => v["nat_gateway"].id if v["nat_gateway"] != null
-  }
-}
-
 resource "azurerm_virtual_network" "this" {
   name                = var.vnet_name
   resource_group_name = var.resource_group_name
   location            = var.location
   address_space       = var.address_spaces
   dns_servers         = var.dns_servers
+
+  dynamic "subnet" {
+    for_each = var.subnets
+
+    content {
+      name             = subnet.value.name
+      address_prefixes = subnet.value.address_prefixes
+
+      security_group = subnet.value.security_group_id
+      route_table_id = subnet.value.route_table_id
+      # TODO(@hknutsen): nat_gateway_id = subnet.value.nat_gateway_id (hashicorp/terraform-provider-azurerm#27199)
+
+      service_endpoints           = subnet.value.service_endpoints
+      service_endpoint_policy_ids = subnet.value.service_endpoint_policy_ids
+
+      dynamic "delegation" {
+        for_each = subnet.value.delegations
+
+        content {
+          # If a name is not explicitly set, set it to the index of the current object.
+          # E.g., if two subnet delegations are to be configured, the first delegation will be named "0" and the second will be named "1".
+          # This is the default naming convention when creating a subnet delegation in the Azure Portal.
+          name = coalesce(delegation.value.name, index(subnet.value.delegations, delegation.value))
+
+          service_delegation {
+            name    = delegation.value.service_name
+            actions = delegation.value.service_actions
+          }
+        }
+      }
+    }
+  }
 
   dynamic "ddos_protection_plan" {
     for_each = var.ddos_protection_plan_id != null ? [0] : []
@@ -29,54 +47,6 @@ resource "azurerm_virtual_network" "this" {
   }
 
   tags = var.tags
-}
-
-resource "azurerm_subnet" "this" {
-  for_each = var.subnets
-
-  name                        = each.value["name"]
-  resource_group_name         = azurerm_virtual_network.this.resource_group_name
-  virtual_network_name        = azurerm_virtual_network.this.name
-  address_prefixes            = each.value["address_prefixes"]
-  service_endpoints           = each.value["service_endpoints"]
-  service_endpoint_policy_ids = each.value["service_endpoint_policy_ids"]
-
-  dynamic "delegation" {
-    for_each = each.value["delegations"]
-
-    content {
-      # If a name is not explicitly set, set it to the index of the current object.
-      # E.g., if two subnet delegations are to be configured, the first delegation will be named "0" and the second will be named "1".
-      # This is the default naming convention when creating a subnet delegation in the Azure Portal.
-      name = coalesce(delegation.value["name"], index(each.value["delegations"], delegation.value))
-
-      service_delegation {
-        name    = delegation.value["service_name"]
-        actions = delegation.value["service_actions"]
-      }
-    }
-  }
-}
-
-resource "azurerm_subnet_network_security_group_association" "this" {
-  for_each = local.subnet_network_security_group_associations
-
-  subnet_id                 = azurerm_subnet.this[each.key].id
-  network_security_group_id = each.value
-}
-
-resource "azurerm_subnet_route_table_association" "this" {
-  for_each = local.subnet_route_table_associations
-
-  subnet_id      = azurerm_subnet.this[each.key].id
-  route_table_id = each.value
-}
-
-resource "azurerm_subnet_nat_gateway_association" "this" {
-  for_each = local.subnet_nat_gateway_associations
-
-  subnet_id      = azurerm_subnet.this[each.key].id
-  nat_gateway_id = each.value
 }
 
 resource "azurerm_virtual_network_peering" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -27,21 +27,13 @@ variable "dns_servers" {
 variable "subnets" {
   description = "A map of subnets to create for this virtual network."
 
-  type = map(object({
+  type = list(object({
     name             = string
     address_prefixes = list(string)
 
-    network_security_group = optional(object({
-      id = string
-    }))
-
-    nat_gateway = optional(object({
-      id = string
-    }))
-
-    route_table = optional(object({
-      id = string
-    }))
+    security_group_id = optional(string)
+    route_table_id    = optional(string)
+    nat_gateway_id    = optional(string)
 
     service_endpoints           = optional(list(string), [])
     service_endpoint_policy_ids = optional(list(string), null)
@@ -53,7 +45,7 @@ variable "subnets" {
     })), [])
   }))
 
-  default = {}
+  default = []
 }
 
 variable "virtual_network_peerings" {


### PR DESCRIPTION
BREAKING CHANGE: remove subnet object properties `network_security_group`, `route_table` and `nat_gateway`. Add subnet object properties `security_group_id`, `route_table_id` and `nat_gateway_id`.