### PR TITLE
feat: add subnet attributes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,12 +34,14 @@ resource "azurerm_virtual_network" "this" {
 resource "azurerm_subnet" "this" {
   for_each = var.subnets
 
-  name                        = each.value["name"]
-  resource_group_name         = azurerm_virtual_network.this.resource_group_name
-  virtual_network_name        = azurerm_virtual_network.this.name
-  address_prefixes            = each.value["address_prefixes"]
-  service_endpoints           = each.value["service_endpoints"]
-  service_endpoint_policy_ids = each.value["service_endpoint_policy_ids"]
+  name                                          = each.value["name"]
+  resource_group_name                           = azurerm_virtual_network.this.resource_group_name
+  virtual_network_name                          = azurerm_virtual_network.this.name
+  address_prefixes                              = each.value["address_prefixes"]
+  service_endpoints                             = each.value["service_endpoints"]
+  service_endpoint_policy_ids                   = each.value["service_endpoint_policy_ids"]
+  private_endpoint_network_policies             = each.value["private_endpoint_network_policies"]
+  private_link_service_network_policies_enabled = each.value["private_link_service_network_policies_enabled"]
 
   dynamic "delegation" {
     for_each = each.value["delegations"]

--- a/variables.tf
+++ b/variables.tf
@@ -43,8 +43,10 @@ variable "subnets" {
       id = string
     }))
 
-    service_endpoints           = optional(list(string), [])
-    service_endpoint_policy_ids = optional(list(string), null)
+    service_endpoints                             = optional(list(string), [])
+    service_endpoint_policy_ids                   = optional(list(string), null)
+    private_endpoint_network_policies             = optional(string, "Disabled")
+    private_link_service_network_policies_enabled = optional(bool, true)
 
     delegations = optional(list(object({
       service_name    = string
@@ -54,6 +56,13 @@ variable "subnets" {
   }))
 
   default = {}
+
+  validation {
+    condition = alltrue([
+      for subnet in var.subnets : contains(["Disabled", "Enabled", "NetworkSecurityGroupEnabled", "RouteTableEnabled"], subnet.private_endpoint_network_policies)
+    ])
+    error_message = "The private_endpoint_network_policies attribute must be one of: Disabled, Enabled, NetworkSecurityGroupEnabled or RouteTableEnabled."
+  }
 }
 
 variable "virtual_network_peerings" {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.39.0"
+      version = ">= 4.0.0"
     }
   }
 }


### PR DESCRIPTION
Due to [changes in default behaviour](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide#azurerm_subnet) on `private_endpoint_network_policies` and `private_link_service_network_policies_enabled` in azurerm version 4 we need to be able to define these values.

Added a validate block for `private_endpoint_network_policies` as its [only accepting certain values](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet#private_endpoint_network_policies)

Not adding this as a breaking change due to conclusion in [Databricks PR](https://github.com/equinor/terraform-azurerm-databricks/pull/35#pullrequestreview-2342457033) that updated versions should not count as a breaking change.