### PR TITLE
feat!: require subnets to be associated with NSG and NAT gateway by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Terraform module which creates Azure Network resources.
 ## Features
 
 - Creates a virtual network in the specified resource group.
-- Creates specified subnets.
+- Associates subnets with specified network security groups for increased security of inbound and outbound traffic by default.
+- Associates subnets with specified NAT gateways for increased reliability of outbound internet traffic by default.
 - Creates specified virtual network peerings.
 
 ## Prerequisites
@@ -32,6 +33,12 @@ module "network" {
     "vm" = {
       name             = "example-vm-snet"
       address_prefixes = ["10.0.1.0/24"]
+      network_security_group = {
+        id = azurerm_network_security_group.example.id
+      }
+      nat_gateway = {
+        id = module.nat_gateway_id
+      }
     }
   }
 }
@@ -41,9 +48,31 @@ resource "azurerm_resource_group" "example" {
   location = "westeurope"
 }
 
-output "vm_subnet_id" {
-  description = "The ID of the subnet to deploy virtual machines into."
-  value       = module.network.subnet_ids["vm"]
+resource "azurerm_network_security_group" "example" {
+  name                = "example-nsg"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+
+  security_rule = []
+}
+
+module "nat" {
+  source  = "equinor/nat/azurerm"
+  version = "~> 3.0"
+
+  gateway_name               = "example-nat"
+  resource_group_name        = azurerm_resource_group.example.name
+  location                   = azurerm_resource_group.example.location
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+}
+
+module "log_analytics" {
+  source  = "equinor/log-analytics/azurerm"
+  version = "~> 2.3"
+
+  workspace_name      = "example-log"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
 }
 ```
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -17,8 +17,10 @@ module "network" {
 
   subnets = {
     "vm" = {
-      name             = "snet-vm-${random_id.suffix.hex}"
-      address_prefixes = ["10.0.1.0/24"]
+      name                   = "snet-vm-${random_id.suffix.hex}"
+      address_prefixes       = ["10.0.1.0/24"]
+      network_security_group = null
+      nat_gateway            = null
     }
   }
 }

--- a/examples/vnet-peering/main.tf
+++ b/examples/vnet-peering/main.tf
@@ -41,8 +41,10 @@ module "network_spoke" {
 
   subnets = {
     "default" = {
-      name             = "default"
-      address_prefixes = ["10.1.1.0/24"]
+      name                   = "default"
+      address_prefixes       = ["10.1.1.0/24"]
+      network_security_group = null
+      nat_gateway            = null
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -31,13 +31,13 @@ variable "subnets" {
     name             = string
     address_prefixes = list(string)
 
-    network_security_group = optional(object({
+    network_security_group = object({
       id = string
-    }))
+    })
 
-    nat_gateway = optional(object({
+    nat_gateway = object({
       id = string
-    }))
+    })
 
     route_table = optional(object({
       id = string

--- a/variables.tf
+++ b/variables.tf
@@ -32,13 +32,13 @@ variable "subnets" {
     address_prefixes = list(string)
 
     # Azure Advisor recommends associating an NSG with subnets to increase
-    # security.
+    # security of inbound and outbound traffic.
     network_security_group = object({
       id = string
     })
 
     # Azure Advisor recommends associating a NAT gateway with subnets to
-    # increase reliability.
+    # increase reliability of outbound internet traffic.
     nat_gateway = object({
       id = string
     })

--- a/variables.tf
+++ b/variables.tf
@@ -31,10 +31,14 @@ variable "subnets" {
     name             = string
     address_prefixes = list(string)
 
+    # Azure Advisor recommends associating an NSG with subnets to increase
+    # security.
     network_security_group = object({
       id = string
     })
 
+    # Azure Advisor recommends associating a NAT gateway with subnets to
+    # increase reliability.
     nat_gateway = object({
       id = string
     })


### PR DESCRIPTION
- Azure Advisor recommends associating an NSG with subnets to increase security of inbound and outbound traffic.
- Azure Advisor recommends associating a NAT gateway with subnets to increase reliability of outbound internet traffic.

BREAKING CHANGE: `subnets` objects properties `network_security_group` and `nat_gateway` are now required by default. Set to `null` to explicitly bypass this requirement for subnets that don't support it (e.g., Azure Bastion subents).